### PR TITLE
Fix unnecessary DescribeDBInstances call with undefined identifier

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -749,6 +749,15 @@ const getServerlessMaxACU = async function (pi, DbiResourceId, endTime) {
 const getGeneralInformation = async function (params, options, snapshotRange) {
   return new Promise(async (resolve, reject) => {
 
+  // Validate that DBInstanceIdentifier is provided to avoid listing all instances
+  // which fails with tag-based IAM policies (see issue #8)
+  if (!params || !params.DBInstanceIdentifier) {
+    const err = new Error('DBInstanceIdentifier is required but was not provided');
+    console.error(err.message);
+    reject(err);
+    return;
+  }
+
   // Getting the current region from instance metadata and setting APIs for the services using this region
   const myRegion = await getCurrentRegion()
   // console.log('AWS Region', myRegion)


### PR DESCRIPTION
## Summary
- Add validation to check that `DBInstanceIdentifier` is provided before calling `describeDBInstances`
- Prevents AccessDenied errors when using tag-based IAM policies

## Problem
When `getGeneralInformation` is called without a valid `DBInstanceIdentifier`, the RDS API call `describeDBInstances` attempts to list ALL instances (`db:*`) instead of a specific instance. This fails with AccessDenied when using tag-based IAM policies that restrict access to specific tagged resources.

The error message shows:
```
Cannot find the instance undefined
AccessDenied: User: ... is not authorized to perform: rds:DescribeDBInstances on resource: arn:aws:rds:us-east-1:*:db:*
```

## Solution
Added input validation at the beginning of `getGeneralInformation()` function in `helpers.js` to check that `params.DBInstanceIdentifier` is provided before making the API call. If not provided, it rejects with a clear error message instead of attempting to list all instances.

## Testing
This fix ensures that:
1. Valid `DBInstanceIdentifier` calls work as before
2. Missing/undefined `DBInstanceIdentifier` is caught early with a clear error message
3. No unnecessary API calls are made to list all instances

Fixes #8