### PR TITLE
Fix TypeError in getServerlessMaxACU when snapshotRange is undefined

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -794,9 +794,12 @@ rds.describeDBInstances(params, async function(err, data) {
           
     //console.log('Output', JSON.stringify(data.DBInstances, null, 2));
     if (DBInstanceClass === 'db.serverless') {
-       try {
-         var {minACUs, maxACUs}  = await getServerlessMaxACU(pi, DbiResourceId, snapshotRange.endTime)
-       } catch (err) { reject(err) }
+       // Only fetch ACU metrics when snapshotRange is available (not during create-report/create-compare-report)
+       if (snapshotRange && snapshotRange.endTime) {
+         try {
+           var {minACUs, maxACUs}  = await getServerlessMaxACU(pi, DbiResourceId, snapshotRange.endTime)
+         } catch (err) { reject(err) }
+       }
     } else {
         try {
           var EC2Instance = await getEC2Details(DBInstanceClass, ec2);


### PR DESCRIPTION
## Summary

Fixes #9 - Periodic error when running against Aurora Serverless create-report or create-compare-report

## Problem

When running `create-report` or `create-compare-report` against Aurora Serverless instances, the code crashes with:
```
TypeError: Cannot read properties of undefined (reading 'getTime')
    at getServerlessMaxACU (helpers.js:693)
```

This happens because:
1. `getGeneralInformation()` is called with `undefined` snapshotRange for report creation
2. For serverless instances (`DBInstanceClass === 'db.serverless'`), it calls `getServerlessMaxACU(pi, DbiResourceId, snapshotRange.endTime)`
3. `snapshotRange.endTime` is `undefined`, causing the crash when `getServerlessMaxACU` tries to call `endTime.getTime()`

## Solution

Added a guard to check if `snapshotRange` and `snapshotRange.endTime` are defined before calling `getServerlessMaxACU`. When these values are undefined (as in create-report/create-compare-report), the ACU metrics call is simply skipped.

## Changes

- `helpers.js`: Added conditional check around `getServerlessMaxACU` call at line 796