### PR TITLE
Fix off-by-one error in calculateSum function

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -317,7 +317,7 @@ const calculateSum = function (numbers) {
     return undefined;
   }
   let sum = 0;
-  for (let i = 1; i < numbers.length; i++) {
+  for (let i = 0; i < numbers.length; i++) {
     if (numbers[i] == null) continue
     sum = sum + numbers[i]
   }


### PR DESCRIPTION
## Summary

- Fixed an off-by-one error in the `calculateSum` function in `helpers.js`

## Bug Description

The `calculateSum` function was starting its loop at index `1` instead of `0`, causing the **first element of every array to be skipped** when calculating sums:

```javascript
// Before (buggy)
for (let i = 1; i < numbers.length; i++) {  // ← starts at 1, skips first element
```

```javascript
// After (fixed)
for (let i = 0; i < numbers.length; i++) {  // ← starts at 0, includes all elements
```

## Impact

This bug affects metric sum calculations in `aurorapg.js` where `calculateSum` is used to aggregate data point values from Performance Insights API responses. The incorrect sums could lead to inaccurate performance metrics being reported in snapshots and reports.

For example, given an array `[100, 1, 1, 1]`:
- **Before fix**: `calculateSum` would return `3` (skipping the `100`)
- **After fix**: `calculateSum` correctly returns `103`

## Testing

- All existing tests pass
- Verified the fix with additional manual tests:
  - `[1, 2, 3, 4, 5]` → correctly returns `15`
  - `[100, 1, 1, 1]` → correctly returns `103`
  - `[42]` → correctly returns `42` (single element)
  - `[]` → correctly returns `undefined` (empty array)
  - `[1, null, 3, null, 5]` → correctly returns `9` (handles null values)